### PR TITLE
feat(sidebar): add home link to tree navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ node_modules
 _drafts
 .vscodevendor/
 .bundle/
+vendor/

--- a/_includes/sidebar-left.html
+++ b/_includes/sidebar-left.html
@@ -4,6 +4,9 @@
     <span class="prompt-user">user@linux</span><span class="prompt-separator">:</span><span class="prompt-path">~</span><span class="prompt-symbol">$</span> tree ~/blog
   </div>
   <div class="panel-content tree-content">
+    <div class="tree-item tree-home">
+      <a href="{{ site.baseurl }}/">home/</a>
+    </div>
     {% assign categories = site.categories | sort %}
     {% assign total_categories = categories | size %}
     {% assign counter = 0 %}
@@ -11,7 +14,7 @@
       {% assign counter = counter | plus: 1 %}
       {% assign cat_name = category[0] %}
       {% assign cat_posts = category[1] %}
-      <div class="tree-item">
+      <div class="tree-item tree-child">
         {% if counter == total_categories %}
         <span class="tree-branch">└──</span>
         {% else %}

--- a/_sass/_post.scss
+++ b/_sass/_post.scss
@@ -123,6 +123,10 @@
         color: #888888;
         margin-left: rem(8px);
       }
+
+      &.tree-child {
+        padding-left: rem(16px);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Add `home/` as parent entry in the sidebar tree for easier navigation back to the home page
- Categories (code, devops, life) are now indented as children of home
- Add vendor/ to .gitignore

## Test plan
- [ ] Verify home/ link appears at top of tree in sidebar
- [ ] Verify clicking home/ navigates to home page
- [ ] Verify categories are properly indented below home/