### PR TITLE
feat: add content workflow tooling and improve CLAUDE.md

### DIFF
--- a/.claude/commands/new-post.md
+++ b/.claude/commands/new-post.md
@@ -1,0 +1,36 @@
+---
+description: Scaffold a new blog post from a GitHub issue
+allowed-tools: Bash, Read, Write, Edit, Grep, Glob
+---
+
+# New Blog Post
+
+Create a new blog post from a GitHub issue.
+
+## Instructions
+
+1. If no issue number was provided as argument ($ARGUMENTS), list open content issues:
+   ```
+   gh issue list --label content --state open
+   ```
+   Ask the user which issue to use.
+
+2. Run the scaffolding script:
+   ```
+   ./scripts/new-post.sh <issue-number>
+   ```
+
+3. Read the created post file and the issue body.
+
+4. Based on the issue outline, generate a suggested post structure with:
+   - An engaging introduction (2-3 sentences)
+   - Section headings derived from the outline points
+   - Placeholder text for each section describing what to cover
+   - A conclusion section
+
+5. Write the suggested structure into the post file, preserving the frontmatter.
+
+6. Ask the user if they want to:
+   - Start writing (fill in sections interactively)
+   - Adjust the structure
+   - Preview locally with `docker compose up`

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/content.yml
+++ b/.github/ISSUE_TEMPLATE/content.yml
@@ -1,0 +1,59 @@
+name: Blog Post Idea
+description: Propose a new blog post for codewizardly.com
+title: "[Content] "
+labels: ["content"]
+body:
+  - type: dropdown
+    id: pillar
+    attributes:
+      label: Pillar
+      description: Which content pillar does this belong to?
+      options:
+        - ai-devops
+        - cloud-native
+        - devsecops
+        - platform-eng
+        - linux
+    validations:
+      required: true
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      description: Blog category for this post
+      options:
+        - devops
+        - code
+        - tutorial
+        - security
+        - life
+        - work
+    validations:
+      required: true
+  - type: textarea
+    id: outline
+    attributes:
+      label: Outline
+      description: Key points or rough outline for the post
+      placeholder: |
+        - Point 1
+        - Point 2
+        - Point 3
+    validations:
+      required: true
+  - type: input
+    id: audience
+    attributes:
+      label: Target Audience
+      description: Who is this post for?
+      placeholder: "e.g., Mid-level DevOps engineers working with Kubernetes"
+    validations:
+      required: false
+  - type: input
+    id: target-date
+    attributes:
+      label: Target Date
+      description: When do you want to publish this? (optional)
+      placeholder: "e.g., 2026-03-15"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/ktlo.yml
+++ b/.github/ISSUE_TEMPLATE/ktlo.yml
@@ -1,0 +1,36 @@
+name: Maintenance Task
+description: Report a bug, request an enhancement, or log a chore
+title: "[KTLO] "
+labels: []
+body:
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type
+      description: What kind of task is this?
+      options:
+        - bug
+        - enhancement
+        - chore
+        - security
+        - dependencies
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What needs to be done?
+      placeholder: Describe the issue or task clearly
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: How do we know this is done?
+      placeholder: |
+        - [ ] Criterion 1
+        - [ ] Criterion 2
+    validations:
+      required: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Personal blog (codewizardly.com) built with Jekyll using the Jekflix template. H
 ## Development Commands
 
 ```bash
-# Docker Compose (recommended)
+# Docker Compose (recommended) - runs on localhost:4000 with livereload on :35729
 docker compose up
 
 # Native Ruby
@@ -19,32 +19,44 @@ bundle install
 bundle exec jekyll serve
 ```
 
+Development uses `_config.yml` + `_config_dev.yml` (overrides URL to localhost:4000).
+
 ## Architecture
 
-### Jekyll Structure
-- `_config.yml` - Main site configuration
-- `_layouts/` - Page templates (post.html, home.html, category.html, etc.)
-- `_includes/` - Reusable HTML components (header, footer, sidebar, etc.)
-- `_sass/` - SCSS stylesheets (main.scss imports all partials)
-- `_posts/YYYY/` - Blog posts organized by year
-- `_authors/` - Author profile definitions
-- `_site/` - Generated output (gitignored)
+### Layout Hierarchy
 
-### Assets
-- `assets/js/` - JavaScript files
-  - `scripts.min.js` - Bundled main JS
-  - `terminal-nav.js` - Terminal-style navigation component
-  - `navigation.json` - Site navigation structure
-- `assets/css/` - Compiled CSS
-- `assets/img/` - Images
+```
+compress.html (HTML minification)
+  └── base.html (HTML shell, header, footer)
+        └── sidebar.html (adds left sidebar)
+        │     └── page.html (static pages: about, contact)
+        │     └── post.html (blog posts)
+        │     └── category.html (category listings)
+        │     └── contact.html (contact form)
+        └── home.html (homepage with hero)
+        └── minimal.html (no-sidebar layouts)
+```
 
-### Key Custom Components
-- Terminal-style sidebar navigation (`_includes/sidebar-left.html`, `terminal-nav.js`)
-- Terminal-style contact form (`_layouts/contact.html`, `terminal-contact.js`)
+### Terminal Navigation System
+
+The site uses a custom terminal/shell-style navigation:
+
+1. **`assets/js/navigation.json`** - Liquid template that generates JSON with all categories and posts at build time
+2. **`assets/js/terminal-nav.js`** - Interactive shell supporting `cd`, `ls`, `cat` commands with fuzzy search (uses Fuse.js)
+3. **`_includes/sidebar-left.html`** - Tree-style category listing (`tree ~/blog`) and recent posts (`top -posts`)
+
+Commands: `cd <category|post>`, `ls [category]`, `cat <post>`, Tab for autocomplete, arrow keys for navigation.
+
+### SCSS Organization
+
+`_sass/main.scss` imports all partials. Key files:
+- `_variables.scss`, `_theme.scss` - Colors, fonts, breakpoints
+- `_layout.scss` - Grid and sidebar layout
+- `_components.scss` - Terminal panels, forms
+- `_post.scss`, `_home.scss` - Page-specific styles
 
 ## Blog Post Format
 
-Posts use front matter:
 ```yaml
 ---
 layout: post
@@ -56,9 +68,12 @@ tags: [tag1, tag2]
 ---
 ```
 
-Categories are defined in `category/` directory with their own front matter.
+Posts go in `_posts/YYYY/` organized by year. Categories are defined in `category/` directory. Use `--page-break--` for content pagination within posts.
 
-## Plugins
+## Key Configuration
 
-- `jekyll-paginate` - Blog post pagination
-- `jekyll-paginate-content` - Content pagination within posts
+`_config.yml` settings:
+- `show_hero: true` - Homepage hero section
+- `show_modal_on_exit: true` - Newsletter modal
+- `two_columns_layout: false` - Post grid style
+- `paginate_content.separator: "--page-break--"` - Multi-page posts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,3 +77,28 @@ Posts go in `_posts/YYYY/` organized by year. Categories are defined in `categor
 - `show_modal_on_exit: true` - Newsletter modal
 - `two_columns_layout: false` - Post grid style
 - `paginate_content.separator: "--page-break--"` - Multi-page posts
+
+## Content Workflow
+
+Two workflows documented in `docs/plans/2026-02-22-content-workflow-design.md`:
+
+### Content Creation (blog posts)
+
+```
+Obsidian (ideation) → GitHub Issue (commitment) → Branch + PR (writing) → Merge (publish)
+```
+
+- Branch naming: `content/<issue-number>-<slug>`
+- Scaffold with: `./scripts/new-post.sh <issue-number>` or `/new-post` command
+- Posts go directly in `_posts/YYYY/` on the branch
+- PR body includes `Closes #<issue-number>`
+- Project board stages: Idea, Outline, Draft, Review, Published
+
+### KTLO (maintenance)
+
+```
+GitHub Issue → Feature branch → Tasks → Single PR → Merge
+```
+
+- Branch naming: `fix/<issue-number>-<slug>` or `feat/<issue-number>-<slug>`
+- Issue templates: use "Blog Post Idea" for content, "Maintenance Task" for KTLO

--- a/scripts/new-post.sh
+++ b/scripts/new-post.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ============================================================================
+# new-post.sh - Scaffold a new blog post from a GitHub issue
+#
+# Usage: ./scripts/new-post.sh <issue-number>
+#
+# Creates:
+#   - Git branch: content/<issue-number>-<slug>
+#   - Post file:  _posts/YYYY/YYYY-MM-DD-<slug>.md
+#   - Image dir:  assets/img/posts/<slug>/
+# ============================================================================
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Valid blog categories (matching category/*.md files)
+VALID_CATEGORIES=("devops" "code" "tutorial" "security" "life" "work")
+
+# Labels to exclude from tags (these are organizational, not content tags)
+PILLAR_LABELS=("content" "ai-devops" "cloud-native" "devsecops" "platform-eng" "linux")
+
+# Default category when none detected from labels
+DEFAULT_CATEGORY="devops"
+
+# --------------------------------------------------------------------------
+# Helpers
+# --------------------------------------------------------------------------
+
+die() {
+    echo "ERROR: $*" >&2
+    exit 1
+}
+
+check_dependency() {
+    command -v "$1" >/dev/null 2>&1 || die "'$1' is required but not installed."
+}
+
+# Convert a title string into a URL-safe slug.
+#   - Strips "[Content] " prefix
+#   - Transliterates accented characters (e.g., e -> e)
+#   - Lowercases
+#   - Replaces non-alphanumeric characters (except hyphens) with hyphens
+#   - Collapses consecutive hyphens
+#   - Trims leading/trailing hyphens
+slugify() {
+    local title="$1"
+
+    # Strip "[Content] " prefix (case-insensitive)
+    title="${title#\[Content\] }"
+    title="${title#\[content\] }"
+
+    # Transliterate accented/unicode chars to ASCII, then slugify
+    if command -v iconv >/dev/null 2>&1; then
+        echo "$title" \
+            | iconv -f UTF-8 -t ASCII//TRANSLIT 2>/dev/null \
+            | tr '[:upper:]' '[:lower:]' \
+            | sed 's/[^a-z0-9-]/-/g' \
+            | sed 's/-\{2,\}/-/g' \
+            | sed 's/^-//' \
+            | sed 's/-$//'
+    else
+        # Fallback: strip non-ASCII bytes before slugifying
+        echo "$title" \
+            | LC_ALL=C tr -dc '[:print:]' \
+            | tr '[:upper:]' '[:lower:]' \
+            | sed 's/[^a-z0-9-]/-/g' \
+            | sed 's/-\{2,\}/-/g' \
+            | sed 's/^-//' \
+            | sed 's/-$//'
+    fi
+}
+
+# Check if a value exists in the VALID_CATEGORIES array
+is_valid_category() {
+    local val="$1"
+    for cat in "${VALID_CATEGORIES[@]}"; do
+        if [[ "$cat" == "$val" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Check if a label is a pillar/organizational label (should be excluded from tags)
+is_pillar_label() {
+    local val="$1"
+    for label in "${PILLAR_LABELS[@]}"; do
+        if [[ "$label" == "$val" ]]; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+# --------------------------------------------------------------------------
+# Argument validation
+# --------------------------------------------------------------------------
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <issue-number>" >&2
+    exit 1
+fi
+
+ISSUE_NUMBER="$1"
+
+if ! [[ "$ISSUE_NUMBER" =~ ^[0-9]+$ ]]; then
+    die "Issue number must be a positive integer, got: '$ISSUE_NUMBER'"
+fi
+
+# --------------------------------------------------------------------------
+# Dependency checks
+# --------------------------------------------------------------------------
+
+check_dependency gh
+check_dependency jq
+
+# --------------------------------------------------------------------------
+# Fetch issue metadata
+# --------------------------------------------------------------------------
+
+echo "Fetching issue #${ISSUE_NUMBER}..."
+
+if ! ISSUE_JSON="$(gh issue view "$ISSUE_NUMBER" --json title,labels 2>&1)"; then
+    die "Failed to fetch issue #${ISSUE_NUMBER}. Is the gh CLI authenticated and are you in the correct repo?
+gh output: $ISSUE_JSON"
+fi
+
+ISSUE_TITLE="$(echo "$ISSUE_JSON" | jq -r '.title')"
+LABELS_JSON="$(echo "$ISSUE_JSON" | jq -r '[.labels[].name]')"
+
+if [[ -z "$ISSUE_TITLE" || "$ISSUE_TITLE" == "null" ]]; then
+    die "Could not parse issue title from issue #${ISSUE_NUMBER}."
+fi
+
+# Strip "[Content] " prefix from title
+CLEAN_TITLE="${ISSUE_TITLE#\[Content\] }"
+CLEAN_TITLE="${CLEAN_TITLE#\[content\] }"
+
+echo "  Title:  $CLEAN_TITLE"
+
+# --------------------------------------------------------------------------
+# Generate slug
+# --------------------------------------------------------------------------
+
+SLUG="$(slugify "$ISSUE_TITLE")"
+
+if [[ -z "$SLUG" ]]; then
+    die "Generated slug is empty. Check issue title: '$ISSUE_TITLE'"
+fi
+
+echo "  Slug:   $SLUG"
+
+# --------------------------------------------------------------------------
+# Detect category from labels
+# --------------------------------------------------------------------------
+
+CATEGORY="$DEFAULT_CATEGORY"
+
+# Read labels into a bash array
+mapfile -t LABELS < <(echo "$LABELS_JSON" | jq -r '.[]')
+
+for label in "${LABELS[@]}"; do
+    if is_valid_category "$label"; then
+        CATEGORY="$label"
+        break
+    fi
+done
+
+echo "  Category: $CATEGORY"
+
+# --------------------------------------------------------------------------
+# Collect tags from labels (exclude content + pillar labels)
+# --------------------------------------------------------------------------
+
+TAGS=()
+for label in "${LABELS[@]}"; do
+    if ! is_pillar_label "$label" && ! is_valid_category "$label"; then
+        TAGS+=("$label")
+    fi
+done
+
+echo "  Tags:   ${TAGS[*]:-<none>}"
+
+# --------------------------------------------------------------------------
+# Derive dates and paths
+# --------------------------------------------------------------------------
+
+TODAY="$(date +%Y-%m-%d)"
+YEAR="$(date +%Y)"
+
+BRANCH_NAME="content/${ISSUE_NUMBER}-${SLUG}"
+POST_DIR="${REPO_ROOT}/_posts/${YEAR}"
+POST_FILE="${POST_DIR}/${TODAY}-${SLUG}.md"
+IMAGE_DIR="${REPO_ROOT}/assets/img/posts/${SLUG}"
+
+# --------------------------------------------------------------------------
+# Safety checks
+# --------------------------------------------------------------------------
+
+if [[ -f "$POST_FILE" ]]; then
+    die "Post file already exists: $POST_FILE"
+fi
+
+# Check for uncommitted changes that could complicate branching
+if ! git -C "$REPO_ROOT" diff-index --quiet HEAD -- 2>/dev/null; then
+    echo "WARNING: You have uncommitted changes. The new branch will include them." >&2
+fi
+
+# --------------------------------------------------------------------------
+# Create git branch
+# --------------------------------------------------------------------------
+
+echo ""
+echo "Creating branch: $BRANCH_NAME"
+git -C "$REPO_ROOT" checkout -b "$BRANCH_NAME"
+
+# --------------------------------------------------------------------------
+# Create directories
+# --------------------------------------------------------------------------
+
+mkdir -p "$POST_DIR"
+mkdir -p "$IMAGE_DIR"
+
+# Add a .gitkeep so the empty image directory is tracked
+touch "${IMAGE_DIR}/.gitkeep"
+
+# --------------------------------------------------------------------------
+# Generate frontmatter and post file
+# --------------------------------------------------------------------------
+
+# Build the tags YAML block
+TAGS_YAML=""
+if [[ ${#TAGS[@]} -gt 0 ]]; then
+    TAGS_YAML="tags:"
+    for tag in "${TAGS[@]}"; do
+        TAGS_YAML="${TAGS_YAML}
+  - ${tag}"
+    done
+else
+    TAGS_YAML="tags: []"
+fi
+
+# Write the post file using a heredoc.
+# Title is quoted to handle colons and special characters in YAML.
+cat > "$POST_FILE" <<EOF
+---
+layout: post
+title: "${CLEAN_TITLE}"
+description:
+image:
+twitter_text:
+date: ${TODAY} 00:00:00
+category: ${CATEGORY}
+${TAGS_YAML}
+author: hector
+paginate: true
+---
+
+<!-- TODO: Write post content for issue #${ISSUE_NUMBER} -->
+EOF
+
+# --------------------------------------------------------------------------
+# Summary
+# --------------------------------------------------------------------------
+
+echo ""
+echo "============================================"
+echo "  Post scaffolding complete!"
+echo "============================================"
+echo ""
+echo "  Branch:     $BRANCH_NAME"
+echo "  Post file:  ${POST_FILE#"$REPO_ROOT"/}"
+echo "  Image dir:  ${IMAGE_DIR#"$REPO_ROOT"/}"
+echo ""
+echo "Next steps:"
+echo "  1. Edit the post file to add content"
+echo "  2. Add a cover image to the image directory"
+echo "  3. Update description, image, and twitter_text in frontmatter"
+echo "  4. Run 'docker compose up' to preview locally"
+echo "  5. Commit and push when ready"
+echo ""

--- a/scripts/new-post.sh
+++ b/scripts/new-post.sh
@@ -93,6 +93,15 @@ is_pillar_label() {
     return 1
 }
 
+# Extract a form field value from a GitHub issue body.
+# GitHub issue forms render dropdown values as:
+#   ### Field Name\n\nvalue\n\n### Next Field
+extract_form_field() {
+    local body="$1"
+    local field="$2"
+    echo "$body" | sed -n "/^### ${field}$/,/^### /{/^### /d;/^$/d;p;}" | head -1 | tr -d '[:space:]'
+}
+
 # --------------------------------------------------------------------------
 # Argument validation
 # --------------------------------------------------------------------------
@@ -121,7 +130,7 @@ check_dependency jq
 
 echo "Fetching issue #${ISSUE_NUMBER}..."
 
-if ! ISSUE_JSON="$(gh issue view "$ISSUE_NUMBER" --json title,labels 2>&1)"; then
+if ! ISSUE_JSON="$(gh issue view "$ISSUE_NUMBER" --json title,labels,body 2>&1)"; then
     die "Failed to fetch issue #${ISSUE_NUMBER}. Is the gh CLI authenticated and are you in the correct repo?
 gh output: $ISSUE_JSON"
 fi
@@ -152,26 +161,41 @@ fi
 echo "  Slug:   $SLUG"
 
 # --------------------------------------------------------------------------
-# Detect category from labels
+# Parse category and pillar from issue body (GitHub form fields)
 # --------------------------------------------------------------------------
+
+ISSUE_BODY="$(echo "$ISSUE_JSON" | jq -r '.body // ""')"
 
 CATEGORY="$DEFAULT_CATEGORY"
 
-# Read labels into a bash array
-mapfile -t LABELS < <(echo "$LABELS_JSON" | jq -r '.[]')
-
-for label in "${LABELS[@]}"; do
-    if is_valid_category "$label"; then
-        CATEGORY="$label"
-        break
-    fi
-done
+# Try to extract category from the issue body (set by the form dropdown)
+BODY_CATEGORY="$(extract_form_field "$ISSUE_BODY" "Category")"
+if [[ -n "$BODY_CATEGORY" ]] && is_valid_category "$BODY_CATEGORY"; then
+    CATEGORY="$BODY_CATEGORY"
+else
+    # Fallback: scan labels for a valid category (for issues not created from template)
+    mapfile -t LABELS < <(echo "$LABELS_JSON" | jq -r '.[]')
+    for label in "${LABELS[@]}"; do
+        if is_valid_category "$label"; then
+            CATEGORY="$label"
+            break
+        fi
+    done
+fi
 
 echo "  Category: $CATEGORY"
 
 # --------------------------------------------------------------------------
-# Collect tags from labels (exclude content + pillar labels)
+# Detect pillar from issue body, collect tags from labels
 # --------------------------------------------------------------------------
+
+# Read labels into array if not already done
+if [[ -z "${LABELS+x}" ]]; then
+    mapfile -t LABELS < <(echo "$LABELS_JSON" | jq -r '.[]')
+fi
+
+# Try to extract pillar from the issue body
+BODY_PILLAR="$(extract_form_field "$ISSUE_BODY" "Pillar")"
 
 TAGS=()
 for label in "${LABELS[@]}"; do
@@ -179,6 +203,21 @@ for label in "${LABELS[@]}"; do
         TAGS+=("$label")
     fi
 done
+
+# Add the pillar as a tag if detected from body and not already in tags
+if [[ -n "$BODY_PILLAR" ]] && ! is_valid_category "$BODY_PILLAR"; then
+    # Check it's not already in TAGS
+    pillar_in_tags=false
+    for tag in "${TAGS[@]}"; do
+        if [[ "$tag" == "$BODY_PILLAR" ]]; then
+            pillar_in_tags=true
+            break
+        fi
+    done
+    if [[ "$pillar_in_tags" == false ]]; then
+        TAGS+=("$BODY_PILLAR")
+    fi
+fi
 
 echo "  Tags:   ${TAGS[*]:-<none>}"
 


### PR DESCRIPTION
## Summary

- Improve CLAUDE.md with architecture details (layout hierarchy, terminal nav system, SCSS organization)
- Add GitHub issue templates for content creation (blog posts) and KTLO (maintenance tasks)
- Add post scaffolding script (`scripts/new-post.sh`) that creates branch, post file, and image directory from a GitHub issue
- Add repo-scoped `/new-post` Claude Code command for AI-assisted post scaffolding
- Document content and KTLO workflows in CLAUDE.md

## Test plan

- [ ] Verify issue templates render correctly at `/issues/new/choose`
- [ ] Test scaffolding script: `./scripts/new-post.sh <issue-number>` against an existing content issue
- [ ] Verify `/new-post` command appears in Claude Code when working in this repo
- [ ] Confirm `docker compose up` serves the site correctly on localhost:4000